### PR TITLE
Use semicolon environment variable separator on win32

### DIFF
--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -43,7 +43,8 @@ class RacerClient
     @racer_bin = @racer_bin or atom.config.get("racer.racerBinPath")
     @rust_src = @rust_src or atom.config.get("racer.rustSrcPath")
     @project_path = @project_path or atom.project.getPath()
-    "#{@rust_src}:#{@project_path}"
+    separator = ';' ? process.platform == 'win32' : ':'
+    "#{@rust_src}#{separator}#{@project_path}"
 
   parse_single: (line) ->
     matches = []


### PR DESCRIPTION
This allows atom-racer to work correctly with racer.exe on Windows.
