### PR TITLE
EMFILE error fix

### DIFF
--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -18,28 +18,28 @@ class RacerClient
       if err
         console.error(err)
         cb null
+      else
+        tempFilePath = info.path
+        cb null unless tempFilePath
 
-      tempFilePath = info.path
-      cb null unless tempFilePath
+        text = editor.getText()
+        fs.writeFileSync tempFilePath, text
+        fs.close(info.fd);
+        options =
+          command: @racer_bin
+          args: ["complete", row + 1, col, tempFilePath]
+          stdout: (output) =>
+            parsed = @parse_single(output)
+            @candidates.push(parsed) if parsed
+            return
+          exit: (code) =>
+            @candidates = _.uniq(_.compact(_.flatten(@candidates)), (e) => e.word + e.file + e.type )
+            cb @candidates
+            return
 
-      text = editor.getText()
-      fs.writeFileSync tempFilePath, text
-
-      options =
-        command: @racer_bin
-        args: ["complete", row + 1, col, tempFilePath]
-        stdout: (output) =>
-          parsed = @parse_single(output)
-          @candidates.push(parsed) if parsed
-          return
-        exit: (code) =>
-          @candidates = _.uniq(_.compact(_.flatten(@candidates)), (e) => e.word + e.file + e.type )
-          cb @candidates
-          return
-
-      @candidates = []
-      process = new BufferedProcess(options)
-      return
+        @candidates = []
+        process = new BufferedProcess(options)
+        return
     return
 
   process_env_vars: ->


### PR DESCRIPTION
After using atom-racer for awhile in one session, I get an EMFILE error from atom-racer, then the error: "Cannot read property 'setEncoding' of undefined" on line 124 of file /usr/share/atom/resources/app/src/buffered-process.js .  EMFILE errors correspond to having too many files open.  It appears that temp.track() only removes the files it created by temp.open() when the process exists, it doesn't automatically close the files while the process is till running.  So if you run atom-racer repeatedly, the amount of open files will increase until your o.s. limit is reached.  Additionally, in the event of a temp.open() error, racer should not be run because it will not have a valid file to read.  I added a fs.close() after fs.writeFileSync() and I haven't seen the error.  I also ensured that racer is only called if temp successfully opens a file.