### PR TITLE
Fixes Atom API deprecated use of project.getPath()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.10.1 (2015-04-13)
+Fixes Atom API deprecated use of project.getPath()
+
+## v0.10.0 (2015-04-11)
+Better handling of temp files
+
+* Close temp files
+* Dont run racer on temp file creation error
+
 ## v0.9.1 (2015-02-04)
 Switch to registering a provider service declaratively through package.json
 

--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -45,7 +45,7 @@ class RacerClient
   process_env_vars: ->
     @racer_bin = @racer_bin or atom.config.get("racer.racerBinPath")
     @rust_src = @rust_src or atom.config.get("racer.rustSrcPath")
-    @project_path = @project_path or atom.project.getPath()
+    @project_path = @project_path or atom.project.getPaths()[0]
     separator = if process.platform is 'win32' then ';' else ':'
     "#{@rust_src}#{separator}#{@project_path}"
 


### PR DESCRIPTION
Use getPath()[0] instead.

Fixes #21 