### PR TITLE
Migrate to autocomplete-plus v2.0 providers API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.11.0 (2015-05-19)
+Migrate to autocomplete-plus v2.0 providers API
+
+* Use the 2.0.0 Provider API from "autocomplete-plus"
+* Add new setting to blacklist user-specified selectors from triggering completion
+* Benefit from the new GUI possibilities of v2 provider's API to give clues about the types of the proposed completions
+* Update dependencies
+
 ## v0.10.1 (2015-04-13)
 Fixes Atom API deprecated use of project.getPath()
 

--- a/lib/racer.coffee
+++ b/lib/racer.coffee
@@ -1,25 +1,32 @@
-RacerProvider = require './racer-provider'
-
 module.exports =
   # Config schema
   config:
-    rustSrcPath:
-      title: 'Path to the Rust source code directory'
-      type: 'string'
-      default: '/usr/local/src/rust/src/'
     racerBinPath:
       title: 'Path to the Racer executable'
       type: 'string'
       default: '/usr/local/bin/racer'
+      order: 1
+    rustSrcPath:
+      title: 'Path to the Rust source code directory'
+      type: 'string'
+      default: '/usr/local/src/rust/src/'
+      order: 2
+    autocompleteBlacklist:
+      title: 'Autocomplete Scope Blacklist'
+      description: 'Autocomplete suggestions will not be shown when the cursor is inside the following comma-delimited scope(s).'
+      type: 'string'
+      default: '.source.go .comment'
+      order: 3
   # members
   racerProvider: null
 
   activate: (state) ->
-    @racerProvider = new RacerProvider()
-    return
 
   provideAutocompletion: ->
-    return {provider: @racerProvider}
+    return @racerProvider if @racerProvider?
+    RacerProvider = require('./racer-provider')
+    @racerProvider = new RacerProvider()
+    return @racerProvider
 
   deactivate: ->
     @racerProvider?.dispose()

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "underscore-plus": "~1.6.1",
+    "underscore-plus": "~1.6.6",
     "temp": "~0.8.1"
   },
   "providedServices": {
     "autocomplete.provider": {
       "description": "Intelligent Rust code completion",
       "versions": {
-        "1.0.0": "provideAutocompletion"
+        "2.0.0": "provideAutocompletion"
       }
     }
   }


### PR DESCRIPTION
* Use the 2.0.0 Provider API from "autocomplete-plus"
* Add new setting to blacklist user-specified selectors from triggering completion
* Benefit from the new GUI possibilities of v2 provider's API to give clues about the types of the proposed completions
* Update dependencies