### PR TITLE
Allow symbolic links to be used for racer executable and rustc sourcecode directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.15.2 (2015-06-24)
+Allow symbolic links to be used for racer executable and rustc sourcecode directory.
+
 ## v0.15.1 (2015-06-24)
 Broken suggestions bug fix.
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 
 go to `Preferences > Packages`, search for `racer`, and click `Settings`
 
-| Display Name                             | Description                                                                                                                                                        | Required | Name                          |
-|:-----------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:------------------------------|
-| Path to the Racer executable             | Full path (including executable) of Racer's binary (e.g. `/Users/me/racer/bin/racer` or `c:\racer\bin\racer.exe`)                                                  | `YES`    | `racer.racerBinPath`          |
-| Path to the Rust source code directory   | Should point to the rustc source directory (e.g. `/Users/me/code/rust/src/`)                                                                                       | `YES`    | `racer.rustSrcPath`           |
-| Autocomplete Scope Blacklist             | Scopes for which no suggestions will be made (e.g. `.source.go .comment`)                                                                                          | `NO`     | `racer.autocompleteBlacklist` |
-| Show position for editor with definition | Can be `Right` or `New`. If `Right` is selected and your view is vertically split, the item will be opened in the rightmost pane of the current active pane's row. | `NO`     | `racer.show`                  |
+| Display Name                             | Description                                                                                                                                                      | Required | Name                          |
+|:-----------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:------------------------------|
+| Path to the Racer executable             | Full path (including executable) of Racer's binary (e.g. `/Users/me/racer/bin/racer` or `c:\racer\bin\racer.exe`)                                                | `YES`    | `racer.racerBinPath`          |
+| Path to the Rust source code directory   | Should point to the rustc source directory (e.g. `/Users/me/code/rust/src/`)                                                                                     | `YES`    | `racer.rustSrcPath`           |
+| Autocomplete Scope Blacklist             | Scopes for which no suggestions will be made (e.g. `.source.go .comment`)                                                                                        | `NO`     | `racer.autocompleteBlacklist` |
+| Show position for editor with definition | Can be `Right` or `New`. If `Right` is selected and your view is vertically split, the item will be open in the rightmost pane of the current active pane's row. | `NO`     | `racer.show`                  |
 
 ## Usage
 

--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -69,7 +69,7 @@ class RacerClient
       conf_bin = atom.config.get("racer.racerBinPath")
       if conf_bin
         try
-          stats = fs.lstatSync(conf_bin);
+          stats = fs.statSync(conf_bin);
           if stats?.isFile()
             @racer_bin = conf_bin
     if !@racer_bin?
@@ -80,7 +80,7 @@ class RacerClient
       conf_src = atom.config.get("racer.rustSrcPath")
       if conf_src
         try
-          stats = fs.lstatSync(conf_src);
+          stats = fs.statSync(conf_src);
           if stats?.isDirectory()
             @rust_src = conf_src
     if !@rust_src?


### PR DESCRIPTION
Also corrects a bad typo in the readme.

Fixes #40 