### PR TITLE
avoid collision of key binding on win32 and linux

### DIFF
--- a/keymaps/racer.cson
+++ b/keymaps/racer.cson
@@ -8,4 +8,4 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-text-editor':
-  'f3': 'racer:find-definition'
+  'f1': 'racer:find-definition'


### PR DESCRIPTION
atom-core defines this keybindings for 'f3' but none for 'f1'

'.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
  'f3': 'find-and-replace:find-next'

This pull requests makes the racer-keybinding work on win32 and linux by default.