### PR TITLE
Show return Type of functions

### DIFF
--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -98,10 +98,12 @@ class RacerClient
 
   parse_single: (line) ->
     matches = []
-    rcrgex = /MATCH (\w*)\,(\d*)\,(\d*)\,([^\,]*)\,(\w*)\,.*\n/mg
+    rcrgex = /MATCH (\w*)\,(\d*)\,(\d*)\,([^\,]*)\,(\w*)\,(.*)\n/mg
+    fnrgx = /( -> .*)/
     while match = rcrgex.exec(line)
+      fnmatch = match[6].match(fnrgx)
       if match?.length > 4
-        candidate = {word: match[1], line: parseInt(match[2], 10), column: parseInt(match[3], 10), filePath: match[4], file: "this", type: match[5]}
+        candidate = {word: match[1] + (fnmatch && fnmatch[0] || ""), line: parseInt(match[2], 10), column: parseInt(match[3], 10), filePath: match[4], file: "this", type: match[5]}
         file_name = path.basename(match[4])
         if path.extname(match[4]).indexOf(".racertmp") == 0
           candidate.filePath = path.dirname(match[4]) + path.sep + file_name.match(/\._(.*)\.racertmp.*?$/)[1]


### PR DESCRIPTION
With this change, when hinting for functions
we not only show the function name but also
it's return value.

E.g.

`get -> Option<&V>`

A picture says more than a thousand words ;)

<img width="637" alt="bildschirmfoto 2015-08-14 um 13 39 15" src="https://cloud.githubusercontent.com/assets/521109/9273260/10d807c4-428b-11e5-9a90-9524938794cd.png">