### PR TITLE
only care about latest process - avoid race conditions

### DIFF
--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -11,6 +11,7 @@ class RacerClient
   project_path: null
   candidates: null
   last_stderr: null
+  last_process: null
 
   check_generator = (racer_action) ->
     (editor, row, col, cb) ->
@@ -44,13 +45,16 @@ class RacerClient
             command: @racer_bin
             args: [racer_action, row + 1, col, tempFilePath]
             stdout: (output) =>
+              return unless this_process == @latest_process
               parsed = @parse_single(output)
               @candidates.push(parsed) if parsed
               return
             stderr: (output) =>
+                return unless this_process == @latest_process
                 @last_stderr = output
                 return
             exit: (code) =>
+              return unless this_process == @latest_process
               @candidates = _.uniq(_.compact(_.flatten(@candidates)), (e) => e.word + e.file + e.type )
               cb @candidates
               temp.cleanup()
@@ -61,7 +65,7 @@ class RacerClient
               return
 
           @candidates = []
-          process = new BufferedProcess(options)
+          @latest_process = this_process = new BufferedProcess(options)
           return
       return
 


### PR DESCRIPTION
Multiple racer processes get spawned simultaneously which leads to race conditions:
1) the winning process deletes the temp files of the other processes causing file not found exceptions
2) the winning process may display results out of sync with the on screen text to autocomplete

e.g. Given line `use std::io::`, type `Bu`. Two temp files get created along with two `racer` processes. If the `B`-process finishes first, its results are offered, both temp files get deleted, and the `u`-process throws an exception. Thus, results which do not match like `Bytes` get displayed. Because it's a race condition, the behavior is inconsistent. Sometimes no exception gets thrown. Sometimes the `u` results get displayed.

This issue makes the package nearly unusable under my dockerized setup.

The current implementation gives preference to the first response (which would usually be the first request). If it weren't for the temp files getting deleting, it would give preference to the last response, which would usually but not always be the last the request. This change enforces that only the last request matters (i.e. the one that matches the latest on screen text to autocomplete) and it greatly narrows the window in which the temp file cleanup will throw an exception.

Ideally, we would have debounce, dedup, and latest request. This adds latest request.