### PR TITLE
Add optional "Cargo home directory" setting

### DIFF
--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -109,7 +109,8 @@ class RacerClient
 
     if config_is_valid
       process.env.RUST_SRC_PATH = @rust_src
-      process.env.CARGO_HOME = @cargo_home
+      if @cargo_home?
+        process.env.CARGO_HOME = @cargo_home
 
     return config_is_valid
 

--- a/lib/racer-client.coffee
+++ b/lib/racer-client.coffee
@@ -8,6 +8,7 @@ module.exports =
 class RacerClient
   racer_bin: null
   rust_src: null
+  cargo_home: null
   project_path: null
   candidates: null
   last_stderr: null
@@ -98,8 +99,17 @@ class RacerClient
       config_is_valid = false
       atom.notifications.addFatalError "racer.rustSrcPath is not set in your config."
 
+    if !@cargo_home?
+      home = atom.config.get("racer.cargoHome")
+      if home
+        try
+          stats = fs.statSync(home);
+          if stats?.isDirectory()
+            @cargo_home = home
+
     if config_is_valid
       process.env.RUST_SRC_PATH = @rust_src
+      process.env.CARGO_HOME = @cargo_home
 
     return config_is_valid
 

--- a/lib/racer.coffee
+++ b/lib/racer.coffee
@@ -14,19 +14,25 @@ module.exports =
       type: 'string'
       default: '/usr/local/src/rust/src/'
       order: 2
+    cargoHome:
+      title: 'Cargo home directory (optional)'
+      type: 'string'
+      description: 'Needed when providing completions for Cargo crates when Cargo is installed in a non-standard location.'
+      default: ''
+      order: 3
     autocompleteBlacklist:
       title: 'Autocomplete Scope Blacklist'
       description: 'Autocomplete suggestions will not be shown when the cursor is inside the following comma-delimited scope(s).'
       type: 'string'
       default: '.source.go .comment'
-      order: 3
+      order: 4
     show:
       title: 'Show position for editor with definition'
       description: 'Choose one: Right, or New. If your view is vertically split, choosing Right will open the definition in the rightmost pane.'
       type: 'string'
       default: 'New'
       enum: ['Right', 'New']
-      order: 4
+      order: 5
   # members
   racerProvider: null
   subscriptions: null


### PR DESCRIPTION
When Cargo is not installed in a standard location, the CARGO_HOME
environment variable must be set to the correct location in order for
racer to be able to provide completions for Cargo packages.

One example of Cargo being installed in a non-standard path is when using [multirust-rs](https://github.com/Diggsey/multirust-rs/issues/46).