### PR TITLE
Add abortKeyBinding to allow overloading keymaps

### DIFF
--- a/lib/racer.coffee
+++ b/lib/racer.coffee
@@ -41,8 +41,8 @@ module.exports =
     @subscriptions = new CompositeDisposable
 
     # Register command that does find-definition
-    @subscriptions.add atom.commands.add 'atom-workspace', 'racer:find-definition': =>
-      @findDefinition()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'racer:find-definition': (e)=>
+      @findDefinition(e)
 
   getRacerProvider: ->
     return @racerProvider if @racerProvider?
@@ -59,11 +59,12 @@ module.exports =
     @subscriptions?.dispose()
     return
 
-  findDefinition: ->
+  findDefinition: (e)->
     textEditor = atom.workspace.getActiveTextEditor()
     grammar = textEditor?.getGrammar()
 
     if !grammar or grammar.name != 'Rust' or textEditor.hasMultipleCursors()
+      e.abortKeyBinding()
       return
 
     cursorPosition = textEditor.getCursorBufferPosition()


### PR DESCRIPTION
Hi.
I added abortKeyBinding to allow overloading key mapping.

Now, `findDefinition` method check condition that the grammar of source code is correct. 
If not, the method quit silently and other keybindings which have same key-map can not know that.

Adding `e. abortKeyBinding `, others could know atom-racer did not handle the key-map.
So this PR may also ease problems like #43 .

http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/#overloading-key-bindings

Regards,