### PR TITLE
Add a provider for hyperclick

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
     "temp": "~0.8.1"
   },
   "providedServices": {
+    "hyperclick.provider": {
+      "versions": {
+        "0.0.0": "provideHyperclick"
+      }
+    },
     "autocomplete.provider": {
       "description": "Intelligent Rust code completion",
       "versions": {


### PR DESCRIPTION
This adds a provider for hyperclick similar to the find-definition method.
Excludes some words based on the editors scope choice (e.g. let language-rust
do the hard work).

To use this, install hyperclick (`apm install hyperclick`) and hold `ctrl` while hovering over a function. It should get an underline and a left click will go to the definition
