### PR TITLE
Fix: atom-racer does not need to create temporary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "underscore-plus": "~1.6.6",
-    "temp": "~0.8.1"
+    "underscore-plus": "~1.6.6"
   },
   "providedServices": {
     "autocomplete.provider": {


### PR DESCRIPTION
atom-racer creates temporary files to provide completion even for unsafed content.
This results in a lot of writes to the disk and is unnecessary. The racer command allows to
pass a subsitute file whose content will be used instead of the file completion is invoked for (its location is used nevertheless).
Instead of specifying a real substitute file '-' is passed and the contents are read from stdin.
This also removes the 'temp' dependency.
